### PR TITLE
Public Wiki default issue

### DIFF
--- a/app/models/wiki.rb
+++ b/app/models/wiki.rb
@@ -1,4 +1,6 @@
 class Wiki < ActiveRecord::Base
   belongs_to :user
-  has_many :sections
+  has_many :sections, dependent: :destroy
+
+  scope :visible_to, -> (user) { user ? all : where(private: false) }
 end

--- a/db/migrate/20150212033640_create_wikis.rb
+++ b/db/migrate/20150212033640_create_wikis.rb
@@ -3,7 +3,7 @@ class CreateWikis < ActiveRecord::Migration
     create_table :wikis do |t|
       t.string :title
       t.text :body
-      t.boolean :private, default: false
+      t.boolean :private
       t.references :user, index: true
 
       t.timestamps

--- a/db/migrate/20150310021156_remove_private_from_wikis.rb
+++ b/db/migrate/20150310021156_remove_private_from_wikis.rb
@@ -1,0 +1,5 @@
+class RemovePrivateFromWikis < ActiveRecord::Migration
+  def change
+    remove_column :wikis, :private, :boolean
+  end
+end

--- a/db/migrate/20150310021421_add_public_to_wikis.rb
+++ b/db/migrate/20150310021421_add_public_to_wikis.rb
@@ -1,0 +1,5 @@
+class AddPublicToWikis < ActiveRecord::Migration
+  def change
+    add_column :wikis, :public, :boolean, :default => true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150303022127) do
+ActiveRecord::Schema.define(version: 20150310021421) do
 
   create_table "sections", force: true do |t|
     t.string   "title"
@@ -50,10 +50,10 @@ ActiveRecord::Schema.define(version: 20150303022127) do
   create_table "wikis", force: true do |t|
     t.string   "title"
     t.text     "body"
-    t.boolean  "private"
     t.integer  "user_id"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.boolean  "public"
   end
 
   add_index "wikis", ["user_id"], name: "index_wikis_on_user_id"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -20,7 +20,7 @@ end
 sections = Section.all
 
 # Create My User
-me = User.create!(
+me = User.new(
   name: "Cole",
   email: "combswc@gmail.com",
   password: "password",
@@ -30,7 +30,7 @@ me.skip_confirmation!
 me.save!
 
 # Create My User
-premium_user = User.create!(
+premium_user = User.new(
   name: "Captain Hook",
   email: "chook@gmail.com",
   password: "password",
@@ -41,7 +41,7 @@ premium_user.save!
 
 # Create Other Users
 3.times do
-  user = User.create!(
+  user = User.new(
     name: Faker::Name.name,
     email: Faker::Internet.email,
     password: "password"


### PR DESCRIPTION
The default value for public in the wikis table isn't working.  Originally it was a column called private but I removed that column and created public for easier readability.  However, neither the original private column nor the new public column will accept the default value I added to their respective migrations.  Ideas?  
